### PR TITLE
Update README.md to fix incorrect markdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/dremio-hub/dremio-internal-function-example.svg?branch=master)](https://travis-ci.org/dremio-hub/dremio-internal-function-example)
 
-This shows an example a customer function using Dremio's internal APIs. The example has the signature example_concat_op(<varchar>, <varchar) and returns a new varchar. It can be used by copying the built jar file into the Dremio jars directory.
+This shows an example a customer function using Dremio's internal APIs. The example has the signature example_concat_op(\<varchar\>, \<varchar\>) and returns a new varchar. It can be used by copying the built jar file into the Dremio jars directory.
 
 Example Usage:
 ```


### PR DESCRIPTION
The varchar operators in the example within the documentation were omitted due to incorrect markdown.